### PR TITLE
Fix roomCode bug

### DIFF
--- a/client/src/homescreen/HomeScreen.js
+++ b/client/src/homescreen/HomeScreen.js
@@ -1,8 +1,8 @@
 import React, { useState, useContext } from "react";
 import { connect } from "react-redux";
-import { setRoom, setUsername } from "../redux/lobby/lobbyActions";
+import { setUsername } from "../redux/lobby/lobbyActions";
 import { WebSocketContext } from '../networking/networking';
-import { Redirect } from "react-router-dom";
+import { Redirect, useLocation } from "react-router-dom";
 import "./HomeScreen.css";
 import logo from "../resource/Whale_Vector.svg";
 
@@ -15,19 +15,18 @@ const formComponents = {
 };
 
 function HomeScreen(props) {
-  let urlParams = new URLSearchParams(props.location?.search);
+  let urlParams = new URLSearchParams(useLocation().search);
 
   const [currentFormComponent, setCurrentFormComponent] = useState(urlParams.get("roomCode") ? formComponents.JOIN : formComponents.MAIN);
-  let initialRoomCode = urlParams.get("roomCode") || props.room?.roomCode || "";
+  let initialRoomCode = props.roomCode || urlParams.get("roomCode") || "";
   const [roomCode, setRoomCode] = useState(initialRoomCode);
   const [roomPassword, setRoomPassword] = useState("");
   const [loading, setLoading] = useState(false);
-  const roomURL = `/room/?roomCode=${roomCode}`;
   const networking = useContext(WebSocketContext);
 
   if (props.connected) {
     // TODO: See if this redirect is breaking url path history
-    return <Redirect to={roomURL} />;
+    return <Redirect to={`/room/?roomCode=${props.roomCode}`} />;
   }
 
   const handleJoinPage = () => {
@@ -193,7 +192,6 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
     return {
         setUsername: (userName) => dispatch(setUsername(userName)),
-        setRoom: (room) => dispatch(setRoom(room)),
     };
 };
 

--- a/client/src/networking/networking.js
+++ b/client/src/networking/networking.js
@@ -105,7 +105,7 @@ export default ({ children }) => {
 
         io.on("disconnect", (msg) => {
             console.log("Disconnected: ", msg);
-            dispatch(setRoom({connected: false}));
+            dispatch(setRoom({}));
         });
     }
 

--- a/client/src/redux/lobby/lobbyReducer.js
+++ b/client/src/redux/lobby/lobbyReducer.js
@@ -5,6 +5,7 @@ const initialState = {
     messages: [],
     songs: [],
     participants: {},
+    roomCode: '',
     connected: false,
 }
 
@@ -42,7 +43,8 @@ const reducer = (state = initialState, action) => {
                 ...state,
                 messages: action.data.room?.messages || [],
                 participants: action.data.room?.participants || {},
-                connected: action.data.room ? action.data.room.connected : false,
+                roomCode: action.data.room?.roomCode || state.roomCode,
+                connected: action.data.room?.connected || false,
             }
         default:
             return state


### PR DESCRIPTION
However, for some reason when a user is given a link with a roomCode, the url params aren't read on the first load.  Not sure if this is a issue in dev mode but useLocation().search is an empty string on first load but refreshing the page makes it work.